### PR TITLE
Fix cast in command-line parsing

### DIFF
--- a/src/anyoption.cpp
+++ b/src/anyoption.cpp
@@ -382,7 +382,7 @@ AnyOption::useCommandArgs( int _argc, QStringList _argv)
 		argv[i] = new char[strlen(_argv.at(i).toStdString().c_str())+1];
 		memcpy(argv[i], _argv.at(i).toStdString().c_str(), strlen(_argv.at(i).toStdString().c_str())+1);
 	}
-	argv[_argv.size()] = ((char)NULL);
+	argv[_argv.size()] = (char*)NULL;
 
 	argc = _argc;
 	command_set = true;


### PR DESCRIPTION
Casting NULL to char breaks the build, as argv is a char* array.

 anyoption.cpp: In member function 'void AnyOption::useCommandArgs(int, QStringList)':
 anyoption.cpp:385:34: error: invalid conversion from 'char' to 'char*' [-fpermissive]
   argv[_argv.size()] = ((char)NULL);