### PR TITLE
Avoid conflict with std::launch

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -36,7 +36,7 @@
 #include "mainwindow.h"
 #include "anyoption.h"
 
-bool launch(AnyOption *cmdopts)
+bool setupOptions(AnyOption *cmdopts)
 {
     cmdopts->addUsage("This is a simple web-browser working in fullscreen kiosk-mode.");
     cmdopts->addUsage("");
@@ -103,7 +103,7 @@ int main(int argc, char * argv[])
     QApplication app(argc, argv);
 
     AnyOption *cmdopts = new AnyOption();
-    if (!launch(cmdopts)) {
+    if (!setupOptions(cmdopts)) {
         return 0;
     }
 


### PR DESCRIPTION
The launch() function would conflict with std::launch from future.h and
cause the build to fail with gcc 6.4[1]:

  main.cpp: In function ‘int main(int, char**)’:
  main.cpp:106:10: error: reference to ‘launch’ is ambiguous
       if (!launch(cmdopts)) {
            ^~~~~~

To prevent this behaviour, rename launch() to setupOptions(), giving it
a more meaningful name.

[1] http://autobuild.buildroot.org/results/bd0/bd02f3dadb710f03cd5026b9da1d7f32552c6c59/build-end.log