### PR TITLE
use QT_NO_SSL to make it openSSL independent

### DIFF
--- a/src/webview.cpp
+++ b/src/webview.cpp
@@ -9,7 +9,9 @@
 
 #ifdef QT5
 #include <QNetworkReply>
+#ifndef QT_NO_SSL
 #include <QSslError>
+#endif
 #endif
 
 
@@ -26,10 +28,12 @@ WebView::WebView(QWidget* parent): QWebView(parent)
  */
 void WebView::initSignals()
 {
+	#ifndef QT_NO_SSL
     connect(page()->networkAccessManager(),
             SIGNAL(sslErrors(QNetworkReply*, const QList<QSslError> & )),
             this,
             SLOT(handleSslErrors(QNetworkReply*, const QList<QSslError> & )));
+	#endif
 
     connect(page(),
             SIGNAL(windowCloseRequested()),
@@ -130,7 +134,7 @@ void WebView::loadCustomPage(QString uri)
     }
 }
 
-
+#ifndef QT_NO_SSL
 void WebView::handleSslErrors(QNetworkReply* reply, const QList<QSslError> &errors)
 {
     qDebug() << QDateTime::currentDateTime().toString() << "handleSslErrors: ";
@@ -147,6 +151,7 @@ void WebView::handleSslErrors(QNetworkReply* reply, const QList<QSslError> &erro
         emit qwkNetworkError(reply->error(), QString("Network SSL errors: ") + errStr);
     }
 }
+#endif
 
 void WebView::handleNetworkReply(QNetworkReply* reply)
 {

--- a/src/webview.h
+++ b/src/webview.h
@@ -68,7 +68,9 @@ private:
     QTimer      *loadTimer;
 
 private slots:
+	#ifndef QT_NO_SSL
     void handleSslErrors(QNetworkReply* reply, const QList<QSslError> &errors);
+	#endif
     void handleWindowCloseRequested();
 
     void handleNetworkReply(QNetworkReply *reply);


### PR DESCRIPTION
Allow to qmake it without openSSL support.

This is needed for old qt 4.8.7 if openssl 1.1.1d support is not given and needs to be dropped.
otherwise the qt-webkit.kiosk will show ssl erros