### PR TITLE
Security option added: local_content_can_access_remote_urls.

### DIFF
--- a/resources/qt-webkit-kiosk.ini
+++ b/resources/qt-webkit-kiosk.ini
@@ -180,3 +180,7 @@ hide_mouse_cursor=false
 
 [localstorage]
 enable=true
+
+[security]
+; Locally loaded documents are allowed to access remote urls.
+local_content_can_access_remote_urls=false

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -268,6 +268,7 @@ void MainWindow::init(AnyOption *opts)
     view->settings()->setAttribute(QWebSettings::JavaEnabled,
         qwkSettings->getBool("browser/java")
     );
+
     view->settings()->setAttribute(QWebSettings::PluginsEnabled,
         qwkSettings->getBool("browser/plugins")
     );
@@ -296,6 +297,10 @@ void MainWindow::init(AnyOption *opts)
         inspector->setWindowIcon(this->windowIcon());
         inspector->setPage(view->page());
     }
+
+    view->settings()->setAttribute(QWebSettings::LocalContentCanAccessRemoteUrls,
+        qwkSettings->getBool("security/local_content_can_access_remote_urls")
+    );
 
     connect(view->page()->mainFrame(), SIGNAL(titleChanged(QString)), SLOT(adjustTitle(QString)));
     connect(view->page()->mainFrame(), SIGNAL(loadStarted()), SLOT(startLoading()));

--- a/src/qwk_settings.cpp
+++ b/src/qwk_settings.cpp
@@ -282,7 +282,11 @@ void QwkSettings::loadSettings(QString ini_file)
     if (!qsettings->contains("localstorage/enable")) {
         qsettings->setValue("localstorage/enable", false);
     }
-    
+
+    if (!qsettings->contains("security/local_content_can_access_remote_urls")) {
+        qsettings->setValue("security/local_content_can_access_remote_urls", false);
+    }
+
     if (qsettings->fileName().length()) {
         qsettings->sync();
     }


### PR DESCRIPTION
Hi,

thanks for the project!
I would like to add  posibility to set QWebSettings::LocalContentCanAccessFileUrls attribute via security/local_content_can_access_remote_urls config option.