### PR TITLE
Fix keys

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -349,6 +349,7 @@ void MainWindow::init(AnyOption *opts)
 
 void MainWindow::delayedWindowResize()
 {
+    qDebug("Setting focus policy, window size");
     this->setFocusPolicy(Qt::StrongFocus);
 
     if (qwkSettings->getBool("view/stay_on_top")) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -349,6 +349,12 @@ void MainWindow::init(AnyOption *opts)
 
 void MainWindow::delayedWindowResize()
 {
+    this->setFocusPolicy(Qt::StrongFocus);
+
+    if (qwkSettings->getBool("view/stay_on_top")) {
+        setWindowFlags(Qt::FramelessWindowHint|Qt::WindowStaysOnTopHint);
+    }
+
     if (qwkSettings->getBool("view/fullscreen")) {
         showFullScreen();
     } else if (qwkSettings->getBool("view/maximized")) {
@@ -358,13 +364,6 @@ void MainWindow::delayedWindowResize()
     }
     QApplication::processEvents(); //process events to force update
 
-    this->setFocusPolicy(Qt::StrongFocus);
-    this->focusWidget();
-
-    if (qwkSettings->getBool("view/stay_on_top")) {
-        setWindowFlags(Qt::FramelessWindowHint|Qt::WindowStaysOnTopHint);
-    }
-    QApplication::processEvents(); //process events to force update
 }
 
 void MainWindow::resizeEvent(QResizeEvent* event)

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -517,7 +517,7 @@ void MainWindow::keyPressEvent(QKeyEvent *event)
         }
         break;
     default:
-        QMainWindow::keyPressEvent(event);
+        view->event(event);
     }
 }
 


### PR DESCRIPTION
The first commit fixes an issue where if you weren't running with a window manager, and you set that config to true, the screen would go black and stay black (there are no other windows) after that callback fires

The third commit fixes an issue where if you weren't running with a window manager, and also had no touchscreen and no mouse, the outer mainwindow always had keyboard focus, so the web app couldn't see any keydown events, and since you had no mouse or touchscreen you couldn't grab the focus to the view. 